### PR TITLE
Fix vercel deployment for node and python servers

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,5 @@
+const app = require('../server');
+
+module.exports = (req, res) => {
+  return app(req, res);
+};

--- a/api/python.py
+++ b/api/python.py
@@ -1,0 +1,10 @@
+import os
+import sys
+
+# Ensure project root is on sys.path so we can import app.py
+CURRENT_DIR = os.path.dirname(__file__)
+PROJECT_ROOT = os.path.abspath(os.path.join(CURRENT_DIR, '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.append(PROJECT_ROOT)
+
+from app import app as app  # Flask app instance

--- a/app.py
+++ b/app.py
@@ -1,6 +1,5 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
-import numpy as np
 import math
 from datetime import datetime, timedelta
 

--- a/public/app.js
+++ b/public/app.js
@@ -54,8 +54,12 @@ const state = {
 };
 
 // ==================== API Configuration ====================
-const API_BASE = 'http://localhost:8080';  // Node.js API server
-const FLASK_API = 'http://localhost:5000'; // Flask server
+// Use relative API paths on production (Vercel). Fall back to localhost in dev.
+const isLocalhost = typeof window !== 'undefined' && 
+    (window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1');
+
+const API_BASE = isLocalhost ? 'http://localhost:8080' : '';
+const FLASK_API = isLocalhost ? 'http://localhost:5000' : '';
 
 // ==================== Initialize App ====================
 document.addEventListener('DOMContentLoaded', () => {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,2 @@
-flask==3.0.0
+Flask==2.3.3
 flask-cors==4.0.0
-requests==2.31.0
-numpy==2.3.3
-python-dotenv==1.0.0

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const path = require('path');
 require('dotenv').config();
 
 const app = express();
-const PORT = 8080;
+const PORT = process.env.PORT || 8080;
 const NASA_API_KEY = process.env.NASA_API_KEY || 'DEMO_KEY';
 
 // Middleware
@@ -1104,9 +1104,14 @@ app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
-// Start server
-app.listen(PORT, () => {
-    console.log(`🚀 Asteroid Impact Simulator Server running on http://localhost:${PORT}`);
-    console.log(`📡 NASA API Key: ${NASA_API_KEY === 'DEMO_KEY' ? 'DEMO_KEY (limited)' : 'Custom key configured'}`);
-    console.log(`\n🌍 Open http://localhost:${PORT} in your browser to start`);
-});
+// Start server only when run directly (not when imported by serverless)
+if (require.main === module && !process.env.VERCEL) {
+    app.listen(PORT, () => {
+        console.log(`🚀 Asteroid Impact Simulator Server running on http://localhost:${PORT}`);
+        console.log(`📡 NASA API Key: ${NASA_API_KEY === 'DEMO_KEY' ? 'DEMO_KEY (limited)' : 'Custom key configured'}`);
+        console.log(`\n🌍 Open http://localhost:${PORT} in your browser to start`);
+    });
+}
+
+// Export the Express app for serverless usage
+module.exports = app;

--- a/vercel.json
+++ b/vercel.json
@@ -1,82 +1,29 @@
 {
   "version": 2,
+  "name": "meteor-madness25",
   "builds": [
-    {
-      "src": "app.py",
-      "use": "@vercel/python"
-    },
-    {
-      "src": "public/**/*",
-      "use": "@vercel/static"
-    }
+    { "src": "api/index.js", "use": "@vercel/node" },
+    { "src": "api/python.py", "use": "@vercel/python" },
+    { "src": "public/**/*", "use": "@vercel/static" }
   ],
-  "rewrites": [
-    {
-      "source": "/api/(.*)",
-      "destination": "/api/$1"
-    },
-    {
-      "source": "/(.*)",
-      "destination": "/public/index.html"
-    }
+  "routes": [
+    { "src": "^/api/calculate/.*", "dest": "/api/python.py" },
+    { "src": "^/api/.*", "dest": "/api/index.js" },
+    { "src": "^/(.*\\.(?:js|css|png|jpg|jpeg|svg|gif|ico|json|map|txt))$", "dest": "/public/$1" },
+    { "src": "^/$", "dest": "/public/index.html" },
+    { "src": "^(?!/api/).*$", "dest": "/public/index.html" }
   ],
   "headers": [
     {
       "source": "/api/(.*)",
       "headers": [
-        {
-          "key": "Access-Control-Allow-Origin",
-          "value": "*"
-        },
-        {
-          "key": "Access-Control-Allow-Methods",
-          "value": "GET, POST, OPTIONS"
-        },
-        {
-          "key": "Access-Control-Allow-Headers",
-          "value": "Content-Type"
-        }
+        { "key": "Access-Control-Allow-Origin", "value": "*" },
+        { "key": "Access-Control-Allow-Methods", "value": "GET, POST, OPTIONS" },
+        { "key": "Access-Control-Allow-Headers", "value": "Content-Type" }
       ]
     }
-  ]
-}
-
-
-
-
-{
-  "version": 3,
-  "name": "meteor-madness25",
-  "builds": [
-    {
-      "src": "frontend/package.json",
-      "use": "@vercel/next",
-      "config": {
-        "distDir": "frontend/.next"
-      }
-    },
-    {
-      "src": "backend-node/api/**/*.js",
-      "use": "@vercel/node"
-    },
-    {
-      "src": "backend-python/api/**/*.py",
-      "use": "@vercel/python"
-    }
   ],
-  "routes": [
-    {
-      "src": "/api/node/(.*)",
-      "dest": "/backend-node/api/$1"
-    },
-    {
-      "src": "/api/python/(.*)",
-      "dest": "/backend-python/api/$1"
-    },
-    // All other routes go to the frontend
-    {
-      "src": "/(.*)",
-      "dest": "/frontend/$1"
-    }
-  ]
+  "env": {
+    "NASA_API_KEY": "@nasa_api_key"
+  }
 }


### PR DESCRIPTION
Configure Vercel to deploy the Node.js and Python Flask application with serverless functions and updated routing.

The previous Vercel configuration was not working, resulting in only the intro screen being displayed and API calls failing due to incorrect server routes and CORS issues. This PR sets up proper Vercel builds and routes for the static frontend, Node.js API, and Python API, and adjusts frontend API URLs to be relative in production.

---
<a href="https://cursor.com/background-agent?bcId=bc-88c4082e-d40e-41af-bba2-a8a01a1fb32d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-88c4082e-d40e-41af-bba2-a8a01a1fb32d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

